### PR TITLE
Add tracking of unmatched requests

### DIFF
--- a/gock.go
+++ b/gock.go
@@ -116,6 +116,11 @@ func GetUnmatchedRequests() []*http.Request {
 	return unmatchedRequests
 }
 
+// HasUnmatchedRequest returns true if gock has received any requests that didn't match a mock
+func HasUnmatchedRequest() bool {
+	return len(GetUnmatchedRequests()) > 0
+}
+
 func trackUnmatchedRequest(req *http.Request) {
 	mutex.Lock()
 	defer mutex.Unlock()

--- a/gock.go
+++ b/gock.go
@@ -17,7 +17,7 @@ var config = struct {
 }{}
 
 // track unmatched requests so they can be tested for
-var unmatchedRequests []*http.Request = []*http.Request{}
+var unmatchedRequests = []*http.Request{}
 
 // New creates and registers a new HTTP mock with
 // default settings and returns the Request DSL for HTTP mock

--- a/gock.go
+++ b/gock.go
@@ -16,6 +16,9 @@ var config = struct {
 	NetworkingFilters []FilterRequestFunc
 }{}
 
+// track unmatched requests so they can be tested for
+var unmatchedRequests []*http.Request = []*http.Request{}
+
 // New creates and registers a new HTTP mock with
 // default settings and returns the Request DSL for HTTP mock
 // definition and set up.
@@ -104,6 +107,19 @@ func DisableNetworkingFilters() {
 	mutex.Lock()
 	defer mutex.Unlock()
 	config.NetworkingFilters = []FilterRequestFunc{}
+}
+
+// GetUnmatchedRequests returns all requests that have been received but haven't matched any mock
+func GetUnmatchedRequests() []*http.Request {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return unmatchedRequests
+}
+
+func trackUnmatchedRequest(req *http.Request) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	unmatchedRequests = append(unmatchedRequests, req)
 }
 
 func normalizeURI(uri string) string {

--- a/gock_test.go
+++ b/gock_test.go
@@ -300,6 +300,23 @@ func TestMockPersistTimes(t *testing.T) {
 	}
 }
 
+func TestUnmatched(t *testing.T) {
+	defer after()
+
+	// clear out any unmatchedRequests from other tests
+	unmatchedRequests = []*http.Request{}
+
+	Intercept()
+
+	_, err := http.Get("http://server.com/unmatched")
+	st.Reject(t, err, nil)
+
+	unmatched := GetUnmatchedRequests()
+	st.Expect(t, len(unmatched), 1)
+	st.Expect(t, unmatched[0].URL.Host, "server.com")
+	st.Expect(t, unmatched[0].URL.Path, "/unmatched")
+}
+
 func TestMultipleMocks(t *testing.T) {
 	defer Disable()
 

--- a/transport.go
+++ b/transport.go
@@ -65,6 +65,7 @@ func (m *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Verify if should use real networking
 	networking := shouldUseNetwork(req, mock)
 	if !networking && mock == nil {
+		trackUnmatchedRequest(req)
 		return nil, ErrCannotMatch
 	}
 


### PR DESCRIPTION
Allows users to write tests to confirm that their code isn't sending any unexpected requests, by calling `gock.GetUnmatchedRequests()`, which returns a slice of HTTP requests that didn't get matched.