### PR TITLE
Update MatchBody() to check equality of JSON key + value pairs regardless of order.

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -2,9 +2,11 @@ package gock
 
 import (
 	"compress/gzip"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"regexp"
 )
 
@@ -161,7 +163,25 @@ func MatchBody(req *http.Request, ereq *Request) (bool, error) {
 
 	// Match request body by regexp
 	match, _ := regexp.MatchString(matchStr, bodyStr)
-	return match, nil
+	if match == true {
+		return true, nil
+	}
+
+	// todo - add conditional do only perform the conversion of body bytes
+	// representation of JSON to a map and then compare them for equality.
+
+	// Check if the key + value pairs match
+	var bodyMap map[string]interface{}
+	var matchMap map[string]interface{}
+
+	// Ensure that both byte bodies that that should be JSON can be converted to maps.
+	umErr := json.Unmarshal(body, &bodyMap)
+	umErr2 := json.Unmarshal(ereq.BodyBuffer, &matchMap)
+	if umErr == nil && umErr2 == nil && reflect.DeepEqual(bodyMap, matchMap) {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func supportedType(req *http.Request) bool {

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -170,6 +170,9 @@ func TestMatchBody(t *testing.T) {
 		{`"foo"`, `{"foo":"bar"}\n`, true},
 		{`{"foo":"bar"}`, `{"foo":"bar"}\n`, true},
 		{`{"foo":"foo"}`, `{"foo":"bar"}\n`, false},
+
+		{`{"foo":"bar","bar":"foo"}`, `{"bar":"foo","foo":"bar"}`, true},
+		{`{"bar":"foo","foo":{"two":"three","three":"two"}}`, `{"foo":{"three":"two","two":"three"},"bar":"foo"}`, true},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
Regarding https://github.com/h2non/gock/issues/15

Update MatchBody() to compare if key + value pairs of JSON match regardless of order they are in.
- Update tests to cover new case where JSON keys and values are not in same order.
- Update tests to include nested fields in JSON.

Please let me know of any suggestions :)