### PR TITLE
fix(store): lock on exist check to avoid race conditions

### DIFF
--- a/store.go
+++ b/store.go
@@ -23,6 +23,8 @@ func Register(mock Mock) {
 
 // GetAll returns the current stack of registed mocks.
 func GetAll() []Mock {
+	mutex.Lock()
+	defer mutex.Unlock()
 	return mocks
 }
 

--- a/store.go
+++ b/store.go
@@ -28,6 +28,9 @@ func GetAll() []Mock {
 
 // Exists checks if the given Mock is already registered.
 func Exists(m Mock) bool {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	for _, mock := range mocks {
 		if mock == m {
 			return true


### PR DESCRIPTION
The race detector found a data race in my tests when adding new mocks while I was polling an endpoint. Locking in `Exists` fixed the issue for me.