### PR TITLE
add example when request reply with error

### DIFF
--- a/_examples/reply_error/reply_error_test.go
+++ b/_examples/reply_error/reply_error_test.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/nbio/st"
+)
+
+func TestReplyError(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://foo.com").
+		Get("/bar").
+		ReplyError(errors.New("Error dude!"))
+
+	_, err := http.Get("http://foo.com/bar")
+	st.Expect(t, err.Error(), "Get http://foo.com/bar: Error dude!")
+
+	// Verify that we don't have pending mocks
+	st.Expect(t, gock.IsDone(), true)
+}


### PR DESCRIPTION
It was a bit harder for me to see how to mock an error from a request.
I need to see the entire code on `request.go`.
I add a simple example to make people easier when need to mock an error request.