### PR TITLE
Make MatchHost case insensitive.

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"reflect"
 	"regexp"
+    "strings"
 )
 
 // EOL represents the end of line character.
@@ -52,7 +53,7 @@ func MatchScheme(req *http.Request, ereq *Request) (bool, error) {
 // MatchHost matches the HTTP host header field of the given request.
 func MatchHost(req *http.Request, ereq *Request) (bool, error) {
 	url := ereq.URLStruct
-	if url.Host == req.URL.Host {
+	if strings.EqualFold(url.Host, req.URL.Host) {
 		return true, nil
 	}
 	return regexp.MatchString(url.Host, req.URL.Host)

--- a/matchers.go
+++ b/matchers.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"reflect"
 	"regexp"
-    "strings"
+	"strings"
 )
 
 // EOL represents the end of line character.

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -59,6 +59,7 @@ func TestMatchHost(t *testing.T) {
 		matches bool
 	}{
 		{"foo.com", "foo.com", true},
+		{"FOO.com", "foo.com", true},
 		{"foo.net", "foo.com", false},
 		{"foo", "foo.com", true},
 		{"(.*).com", "foo.com", true},


### PR DESCRIPTION
According to [rfc7230](https://tools.ietf.org/html/rfc7230), host part of http URI is case insensitive, 
> The scheme and host are case-insensitive and normally provided in lowercase

Function `MatchHost` should use `strings.EqualFold` instead of `==`.