### PR TITLE
fix(url-encoding) add exact match test in MatchPath

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -61,6 +61,9 @@ func MatchHost(req *http.Request, ereq *Request) (bool, error) {
 
 // MatchPath matches the HTTP URL path of the given request.
 func MatchPath(req *http.Request, ereq *Request) (bool, error) {
+	if req.URL.Path == ereq.URLStruct.Path {
+		return true, nil
+	}
 	return regexp.MatchString(ereq.URLStruct.Path, req.URL.Path)
 }
 

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -93,6 +93,7 @@ func TestMatchPath(t *testing.T) {
 		{"/foo/[a-z]+", "/foo/bar", true},
 		{"/foo/baz", "/foo/bar", false},
 		{"/foo/baz", "/foo/bar", false},
+		{"/foo/bar%3F+%C3%A9", "/foo/bar%3F+%C3%A9", true},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
When using a path containing a "QueryEscape"d string, the `MatchPath` will fail as it considers the expectation request path to be a regexp. This PR allows to pass an exact match.
