### PR TITLE
Support multiple response headers with same name #35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: go
 
 go:
+  - "1.11"
   - "1.10"
   - "1.92"
   - "1.82"
   - "1.72"
   - "1.62"
-  - "tip"
+  - "stable"
 
 before_install:
   - go get -u github.com/nbio/st

--- a/responder.go
+++ b/responder.go
@@ -71,8 +71,10 @@ func createResponse(req *http.Request) *http.Response {
 
 // mergeHeaders copies the mock headers.
 func mergeHeaders(res *http.Response, mres *Response) http.Header {
-	for key := range mres.Header {
-		res.Header.Set(key, mres.Header.Get(key))
+	for key, values := range mres.Header {
+		for _, value := range values {
+			res.Header.Add(key, value)
+		}
 	}
 	return res.Header
 }

--- a/responder_test.go
+++ b/responder_test.go
@@ -23,6 +23,19 @@ func TestResponder(t *testing.T) {
 	st.Expect(t, string(body), "foo")
 }
 
+func TestResponderSupportsMultipleHeadersWithSameKey(t *testing.T) {
+	defer after()
+	mres := New("http://foo").
+		Reply(200).
+		AddHeader("Set-Cookie", "a=1").
+		AddHeader("Set-Cookie", "b=2")
+	req := &http.Request{}
+
+	res, err := Responder(req, mres, nil)
+	st.Expect(t, err, nil)
+	st.Expect(t, res.Header, http.Header{"Set-Cookie": []string{"a=1", "b=2"}})
+}
+
 func TestResponderError(t *testing.T) {
 	defer after()
 	mres := New("http://foo.com").ReplyError(errors.New("error"))


### PR DESCRIPTION
This change adds support for defining multiple headers with the same name on a response. This is commonly desired when using `Set-Cookie`