### PR TITLE
Do not reset response body

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -3,6 +3,7 @@ package gock
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -82,20 +83,5 @@ func mergeHeaders(res *http.Response, mres *Response) http.Header {
 // createReadCloser creates an io.ReadCloser from a byte slice that is suitable for use as an
 // http response body.
 func createReadCloser(body []byte) io.ReadCloser {
-	return &dummyReadCloser{body: bytes.NewReader(body)}
-}
-
-// dummyReadCloser is used internally as io.ReadCloser capable interface for bodies.
-type dummyReadCloser struct {
-	body io.ReadSeeker
-}
-
-// Read implements the required method by io.ReadClose interface.
-func (d *dummyReadCloser) Read(p []byte) (n int, err error) {
-	return d.body.Read(p)
-}
-
-// Close implements a no-op required method by io.ReadClose interface.
-func (d *dummyReadCloser) Close() error {
-	return nil
+	return ioutil.NopCloser(bytes.NewReader(body))
 }

--- a/responder.go
+++ b/responder.go
@@ -92,11 +92,7 @@ type dummyReadCloser struct {
 
 // Read implements the required method by io.ReadClose interface.
 func (d *dummyReadCloser) Read(p []byte) (n int, err error) {
-	n, err = d.body.Read(p)
-	if err == io.EOF {
-		d.body.Seek(0, 0)
-	}
-	return n, err
+	return d.body.Read(p)
 }
 
 // Close implements a no-op required method by io.ReadClose interface.

--- a/responder_test.go
+++ b/responder_test.go
@@ -23,6 +23,24 @@ func TestResponder(t *testing.T) {
 	st.Expect(t, string(body), "foo")
 }
 
+func TestResponder_ReadTwice(t *testing.T) {
+	defer after()
+	mres := New("http://foo.com").Reply(200).BodyString("foo")
+	req := &http.Request{}
+
+	res, err := Responder(req, mres, nil)
+	st.Expect(t, err, nil)
+	st.Expect(t, res.Status, "200 OK")
+	st.Expect(t, res.StatusCode, 200)
+
+	body, _ := ioutil.ReadAll(res.Body)
+	st.Expect(t, string(body), "foo")
+
+	body, err = ioutil.ReadAll(res.Body)
+	st.Expect(t, err, nil)
+	st.Expect(t, body,[]byte{})
+}
+
 func TestResponderSupportsMultipleHeadersWithSameKey(t *testing.T) {
 	defer after()
 	mres := New("http://foo").

--- a/responder_test.go
+++ b/responder_test.go
@@ -38,7 +38,7 @@ func TestResponder_ReadTwice(t *testing.T) {
 
 	body, err = ioutil.ReadAll(res.Body)
 	st.Expect(t, err, nil)
-	st.Expect(t, body,[]byte{})
+	st.Expect(t, body, []byte{})
 }
 
 func TestResponderSupportsMultipleHeadersWithSameKey(t *testing.T) {


### PR DESCRIPTION
Mocked response body does not match the real http.Response.Body behavior. 
Response body should not be reset when it is read till EOF.

If you accidentally read response body twice tests using mocked response won't fail, but they should.