### PR TITLE
Fix possible data race.

### DIFF
--- a/gock.go
+++ b/gock.go
@@ -52,6 +52,8 @@ func New(uri string) *Request {
 
 // Intercepting returns true if gock is currently able to intercept.
 func Intercepting() bool {
+	mutex.Lock()
+	defer mutex.Unlock()
 	return http.DefaultTransport == DefaultTransport
 }
 


### PR DESCRIPTION
Hi, I've been encountering a data race in my tests:
```bash
WARNING: DATA RACE
Read at 0x000002b7e360 by goroutine 148:
  github.com/presslabs/dashboard/vendor/gopkg.in/h2non/gock%2ev1.(*Transport).RoundTrip()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/gopkg.in/h2non/gock.v1/gock.go:55 +0x55
  github.com/presslabs/dashboard/vendor/k8s.io/client-go/transport.(*userAgentRoundTripper).RoundTrip()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/k8s.io/client-go/transport/round_trippers.go:162 +0x1a6
  net/http.send()
      /usr/lib/go/src/net/http/client.go:250 +0x304
  net/http.(*Client).send()
      /usr/lib/go/src/net/http/client.go:174 +0x1ca
  net/http.(*Client).do()
      /usr/lib/go/src/net/http/client.go:641 +0x531
  net/http.(*Client).Do()
      /usr/lib/go/src/net/http/client.go:509 +0x42
  github.com/presslabs/dashboard/vendor/k8s.io/client-go/rest.(*Request).request()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/k8s.io/client-go/rest/request.go:687 +0x57c
  github.com/presslabs/dashboard/vendor/k8s.io/client-go/rest.(*Request).Do()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/k8s.io/client-go/rest/request.go:759 +0xd5
  github.com/presslabs/dashboard/vendor/k8s.io/client-go/kubernetes/typed/core/v1.(*events).CreateWithEventNamespace()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go:57 +0x1f0
  github.com/presslabs/dashboard/vendor/k8s.io/client-go/kubernetes/typed/core/v1.(*EventSinkImpl).Create()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go:155 +0x5e
  github.com/presslabs/dashboard/vendor/k8s.io/client-go/tools/record.recordEvent()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/k8s.io/client-go/tools/record/event.go:184 +0xe9
  github.com/presslabs/dashboard/vendor/k8s.io/client-go/tools/record.recordToSink()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/k8s.io/client-go/tools/record/event.go:142 +0x20d
  github.com/presslabs/dashboard/vendor/k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartRecordingToSink.func1()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/k8s.io/client-go/tools/record/event.go:124 +0xb8
  github.com/presslabs/dashboard/vendor/k8s.io/client-go/tools/record.(*eventBroadcasterImpl).StartEventWatcher.func1()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/k8s.io/client-go/tools/record/event.go:238 +0xfb

Previous write at 0x000002b7e360 by goroutine 14:
  github.com/presslabs/dashboard/vendor/gopkg.in/h2non/gock%2ev1.Disable()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/gopkg.in/h2non/gock.v1/gock.go:92 +0xc2
  github.com/presslabs/dashboard/pkg/controller/project.glob..func2()
      /home/bgd/go/src/github.com/presslabs/dashboard/pkg/controller/project/project_controller_suite_test.go:63 +0x54
  github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113 +0xbd
  github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).run()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:64 +0x16a
  github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*simpleSuiteNode).Run()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/leafnodes/suite_nodes.go:25 +0xb2
  github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runAfterSuite()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:138 +0x153
  github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:71 +0x101
  github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/suite.(*Suite).Run()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:62 +0x3e1
  github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo.RunSpecsWithCustomReporters()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:221 +0x367
  github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters()
      /home/bgd/go/src/github.com/presslabs/dashboard/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:209 +0x129
  github.com/presslabs/dashboard/pkg/controller/project.TestProjectController()
      /home/bgd/go/src/github.com/presslabs/dashboard/pkg/controller/project/project_controller_suite_test.go:42 +0x157
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:827 +0x162
```
Using the mutex fixes it.