### PR TITLE
Add PathParam matcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 
 before_install:
   - go get -u github.com/nbio/st
+  - go get -u github.com/codemodus/parth
   - go get -u gopkg.in/h2non/gentleman.v1
   - go get -u -v github.com/axw/gocov/gocov
   - go get -u -v github.com/mattn/goveralls

--- a/matcher.go
+++ b/matcher.go
@@ -10,6 +10,7 @@ var MatchersHeader = []MatchFunc{
 	MatchPath,
 	MatchHeaders,
 	MatchQueryParams,
+	MatchPathParams,
 }
 
 // MatchersBody exposes an slice of HTTP body specific built-in mock matchers.

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRegisteredMatchers(t *testing.T) {
-	st.Expect(t, len(MatchersHeader), 6)
+	st.Expect(t, len(MatchersHeader), 7)
 	st.Expect(t, len(MatchersBody), 1)
 }
 

--- a/matchers.go
+++ b/matchers.go
@@ -115,6 +115,7 @@ func MatchQueryParams(req *http.Request, ereq *Request) (bool, error) {
 	return true, nil
 }
 
+// MatchPathParams matches the URL path parameters of the given request.
 func MatchPathParams(req *http.Request, ereq *Request) (bool, error) {
 	for key, value := range ereq.PathParams {
 		var s string

--- a/matchers.go
+++ b/matchers.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/codemodus/parth"
 )
 
 // EOL represents the end of line character.
@@ -107,6 +109,21 @@ func MatchQueryParams(req *http.Request, ereq *Request) (bool, error) {
 		}
 
 		if !match {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func MatchPathParams(req *http.Request, ereq *Request) (bool, error) {
+	for key, value := range ereq.PathParams {
+		var s string
+
+		if err := parth.Sequent(req.URL.Path, key, &s); err != nil {
+			return false, nil
+		}
+
+		if s != value {
 			return false, nil
 		}
 	}

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -160,6 +160,33 @@ func TestMatchQueryParams(t *testing.T) {
 	}
 }
 
+func TestMatchPathParams(t *testing.T) {
+	cases := []struct {
+		key     string
+		value   string
+		path    string
+		matches bool
+	}{
+		{"foo", "bar", "/foo/bar", true},
+		{"foo", "bar", "/foo/test/bar", false},
+		{"foo", "bar", "/test/foo/bar/ack", true},
+		{"foo", "bar", "/foo", false},
+	}
+
+	for i, test := range cases {
+		u, _ := url.Parse("http://foo.com" + test.path)
+		mu, _ := url.Parse("http://foo.com" + test.path)
+		req := &http.Request{URL: u}
+		ereq := &Request{
+			URLStruct:  mu,
+			PathParams: map[string]string{test.key: test.value},
+		}
+		matches, err := MatchPathParams(req, ereq)
+		st.Expect(t, err, nil, i)
+		st.Expect(t, matches, test.matches, i)
+	}
+}
+
 func TestMatchBody(t *testing.T) {
 	cases := []struct {
 		value   string

--- a/request.go
+++ b/request.go
@@ -47,6 +47,9 @@ type Request struct {
 	// Cookies stores the Request HTTP cookies values to match.
 	Cookies []*http.Cookie
 
+	// PathParams stores the path parameters to match.
+	PathParams map[string]string
+
 	// BodyBuffer stores the body data to match.
 	BodyBuffer []byte
 
@@ -60,9 +63,10 @@ type Request struct {
 // NewRequest creates a new Request instance.
 func NewRequest() *Request {
 	return &Request{
-		Counter:   1,
-		URLStruct: &url.URL{},
-		Header:    make(http.Header),
+		Counter:    1,
+		URLStruct:  &url.URL{},
+		Header:     make(http.Header),
+		PathParams: make(map[string]string),
 	}
 }
 
@@ -219,6 +223,18 @@ func (r *Request) MatchParams(params map[string]string) *Request {
 // ParamPresent matches if the given query param key is present in the URL.
 func (r *Request) ParamPresent(key string) *Request {
 	r.MatchParam(key, ".*")
+	return r
+}
+
+// PathParam matches if a given path parameter key is present in the URL.
+//
+// The value is representative of the restful resource the key defines, e.g.
+//   // /users/123/name
+//   r.PathParam("users", "123")
+// would match.
+func (r *Request) PathParam(key, val string) *Request {
+	r.PathParams[key] = val
+
 	return r
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -121,6 +121,12 @@ func TestRequestPresentParam(t *testing.T) {
 	st.Expect(t, req.URLStruct.Query().Get("key"), ".*")
 }
 
+func TestRequestPathParam(t *testing.T) {
+	req := NewRequest()
+	req.PathParam("key", "value")
+	st.Expect(t, req.PathParams["key"], "value")
+}
+
 func TestRequestPersist(t *testing.T) {
 	req := NewRequest()
 	st.Expect(t, req.Persisted, false)

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package gock
 
 // Version defines the current package semantic version.
-const Version = "1.0.12"
+const Version = "1.0.13"


### PR DESCRIPTION
This matcher is useful for mocking a restful SDK, where you may want
to alter the response based on a provide path parameter. Standard
restful path parameters follow the patterm of {resource}/{id}, usage
follows that pattern by providing the resource `key` which should match
against the id `value`.