### PR TITLE
add option to disable regexp host matching

### DIFF
--- a/_examples/reply_error/reply_error_test.go
+++ b/_examples/reply_error/reply_error_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/h2non/gock"
 	"github.com/nbio/st"
+	"gopkg.in/h2non/gock.v1"
 )
 
 func TestReplyError(t *testing.T) {

--- a/matchers.go
+++ b/matchers.go
@@ -58,7 +58,10 @@ func MatchHost(req *http.Request, ereq *Request) (bool, error) {
 	if strings.EqualFold(url.Host, req.URL.Host) {
 		return true, nil
 	}
-	return regexp.MatchString(url.Host, req.URL.Host)
+	if !ereq.Options.DisableRegexpHost {
+		return regexp.MatchString(url.Host, req.URL.Host)
+	}
+	return false, nil
 }
 
 // MatchPath matches the HTTP URL path of the given request.

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -54,19 +54,21 @@ func TestMatchScheme(t *testing.T) {
 
 func TestMatchHost(t *testing.T) {
 	cases := []struct {
-		value   string
-		url     string
-		matches bool
+		value            string
+		url              string
+		matches          bool
+		matchesNonRegexp bool
 	}{
-		{"foo.com", "foo.com", true},
-		{"FOO.com", "foo.com", true},
-		{"foo.net", "foo.com", false},
-		{"foo", "foo.com", true},
-		{"(.*).com", "foo.com", true},
-		{"127.0.0.1", "127.0.0.1", true},
-		{"127.0.0.2", "127.0.0.1", false},
-		{"127.0.0.*", "127.0.0.1", true},
-		{"127.0.0.[0-9]", "127.0.0.7", true},
+		{"foo.com", "foo.com", true, true},
+		{"FOO.com", "foo.com", true, true},
+		{"foo.net", "foo.com", false, false},
+		{"foo.bar.net", "foo-bar.net", true, false},
+		{"foo", "foo.com", true, false},
+		{"(.*).com", "foo.com", true, false},
+		{"127.0.0.1", "127.0.0.1", true, true},
+		{"127.0.0.2", "127.0.0.1", false, false},
+		{"127.0.0.*", "127.0.0.1", true, false},
+		{"127.0.0.[0-9]", "127.0.0.7", true, false},
 	}
 
 	for _, test := range cases {
@@ -75,6 +77,10 @@ func TestMatchHost(t *testing.T) {
 		matches, err := MatchHost(req, ereq)
 		st.Expect(t, err, nil)
 		st.Expect(t, matches, test.matches)
+		ereq.WithOptions(Options{DisableRegexpHost: true})
+		matches, err = MatchHost(req, ereq)
+		st.Expect(t, err, nil)
+		st.Expect(t, matches, test.matchesNonRegexp)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -1,0 +1,8 @@
+package gock
+
+// Options represents customized option for gock
+type Options struct {
+	// DisableRegexpHost stores if the host is only a plain string rather than regular expression,
+	// if DisableRegexpHost is true, host sets in gock.New(...) will be treated as plain string
+	DisableRegexpHost bool
+}

--- a/request.go
+++ b/request.go
@@ -33,6 +33,9 @@ type Request struct {
 	// Persisted stores if the current mock should be always active.
 	Persisted bool
 
+	// Options stores options for current Request.
+	Options Options
+
 	// URLStruct stores the parsed URL as *url.URL struct.
 	URLStruct *url.URL
 
@@ -248,6 +251,12 @@ func (r *Request) PathParam(key, val string) *Request {
 // Persist defines the current HTTP mock as persistent and won't be removed after intercepting it.
 func (r *Request) Persist() *Request {
 	r.Persisted = true
+	return r
+}
+
+// WithOptions sets the options for the request.
+func (r *Request) WithOptions(options Options) *Request {
+	r.Options = options
 	return r
 }
 


### PR DESCRIPTION
MatchHost function treats host string as plain string but also regexp, which might cause some unexpected condition, like `foo.bar.com` matches `foo-bar.com`.
However nock can distinguish plain string and regexp (regexp in js surrounded by /)

This PR adds request.DisableRegexpHostMatching to treat host only as string. After calling DisableRegexpHostMatching, MatchHost will not using regular expression. Regexp host matching is enabled default to keep compatibility.

Before:
```golang
gock.New("http://foo.bar.com").
		Get("/bar").
		Reply(200).
		JSON(map[string]string{"foo": "bar"})
http.Get("http://foo-bar.com/bar") // match
```
After calling DisableRegexpHostMatching
```golang
gock.New("http://foo.bar.com").
		DisableRegexpHostMatching().
		Get("/bar").
		Reply(200).
		JSON(map[string]string{"foo": "bar"})
http.Get("http://foo-bar.com/bar") // not match
```