### PR TITLE
NewMatcher() will now return objects that completely separate one another.

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -55,7 +55,7 @@ type MockMatcher struct {
 // using the default matcher functions.
 func NewMatcher() *MockMatcher {
 	m := NewEmptyMatcher()
-	for _, matchFn := range gock.Matchers{
+	for _, matchFn := range Matchers{
 		m.Add(matchFn)
 	}
 	return m
@@ -64,7 +64,7 @@ func NewMatcher() *MockMatcher {
 // NewBasicMatcher creates a new matcher with header only mock matchers.
 func NewBasicMatcher() *MockMatcher {
 	m := NewEmptyMatcher()
-	for _, matchFn := range gock.MatchersHeader{
+	for _, matchFn := range MatchersHeader{
 		m.Add(matchFn)
 	}
 	return m

--- a/matcher.go
+++ b/matcher.go
@@ -95,6 +95,14 @@ func (m *MockMatcher) Flush() {
 	m.Matchers = []MatchFunc{}
 }
 
+func (m *MockMatcher) Clone() *MockMatcher {
+	m2 := NewEmptyMatcher()
+	for _, mFn := range m.Get() {
+		m2.Add(mFn)
+	}
+	return m2
+}
+
 // Match matches the given http.Request with a mock request
 // returning true in case that the request matches, otherwise false.
 func (m *MockMatcher) Match(req *http.Request, ereq *Request) (bool, error) {

--- a/matcher.go
+++ b/matcher.go
@@ -95,6 +95,7 @@ func (m *MockMatcher) Flush() {
 	m.Matchers = []MatchFunc{}
 }
 
+// Clone returns a separate MockMatcher instance that has a copy of the same MatcherFuncs
 func (m *MockMatcher) Clone() *MockMatcher {
 	m2 := NewEmptyMatcher()
 	for _, mFn := range m.Get() {

--- a/matcher.go
+++ b/matcher.go
@@ -55,7 +55,7 @@ type MockMatcher struct {
 // using the default matcher functions.
 func NewMatcher() *MockMatcher {
 	m := NewEmptyMatcher()
-	for _, matchFn := range Matchers{
+	for _, matchFn := range Matchers {
 		m.Add(matchFn)
 	}
 	return m
@@ -64,7 +64,7 @@ func NewMatcher() *MockMatcher {
 // NewBasicMatcher creates a new matcher with header only mock matchers.
 func NewBasicMatcher() *MockMatcher {
 	m := NewEmptyMatcher()
-	for _, matchFn := range MatchersHeader{
+	for _, matchFn := range MatchersHeader {
 		m.Add(matchFn)
 	}
 	return m

--- a/matcher.go
+++ b/matcher.go
@@ -54,15 +54,23 @@ type MockMatcher struct {
 // NewMatcher creates a new mock matcher
 // using the default matcher functions.
 func NewMatcher() *MockMatcher {
-	return &MockMatcher{Matchers: Matchers}
+	m := NewEmptyMatcher()
+	for _, matchFn := range gock.Matchers{
+		m.Add(matchFn)
+	}
+	return m
 }
 
 // NewBasicMatcher creates a new matcher with header only mock matchers.
 func NewBasicMatcher() *MockMatcher {
-	return &MockMatcher{Matchers: MatchersHeader}
+	m := NewEmptyMatcher()
+	for _, matchFn := range gock.MatchersHeader{
+		m.Add(matchFn)
+	}
+	return m
 }
 
-// NewEmptyMatcher creates a new empty matcher with out default amtchers.
+// NewEmptyMatcher creates a new empty matcher without default matchers.
 func NewEmptyMatcher() *MockMatcher {
 	return &MockMatcher{Matchers: []MatchFunc{}}
 }

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -71,6 +71,11 @@ func TestMatcherFlush(t *testing.T) {
 	st.Expect(t, len(matcher.Get()), 0)
 }
 
+func TestMatcherClone(t *testing.T) {
+	matcher := DefaultMatcher.Clone()
+	st.Expect(t, len(matcher.Get()), len(DefaultMatcher.Get()))
+}
+
 func TestMatcher(t *testing.T) {
 	cases := []struct {
 		method  string

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -15,14 +15,18 @@ func TestRegisteredMatchers(t *testing.T) {
 
 func TestNewMatcher(t *testing.T) {
 	matcher := NewMatcher()
-	st.Expect(t, matcher.Matchers, Matchers)
-	st.Expect(t, matcher.Get(), Matchers)
+	// Funcs are not comparable, checking slice length as it's better than nothing
+	// See https://golang.org/pkg/reflect/#DeepEqual
+	st.Expect(t, len(matcher.Matchers), len(Matchers))
+	st.Expect(t, len(matcher.Get()), len(Matchers))
 }
 
 func TestNewBasicMatcher(t *testing.T) {
 	matcher := NewBasicMatcher()
-	st.Expect(t, matcher.Matchers, MatchersHeader)
-	st.Expect(t, matcher.Get(), MatchersHeader)
+	// Funcs are not comparable, checking slice length as it's better than nothing
+	// See https://golang.org/pkg/reflect/#DeepEqual
+	st.Expect(t, len(matcher.Matchers), len(MatchersHeader))
+	st.Expect(t, len(matcher.Get()), len(MatchersHeader))
 }
 
 func TestNewEmptyMatcher(t *testing.T) {

--- a/mock.go
+++ b/mock.go
@@ -55,7 +55,7 @@ func NewMock(req *Request, res *Response) *Mocker {
 	mock := &Mocker{
 		request:  req,
 		response: res,
-		matcher:  DefaultMatcher,
+		matcher:  DefaultMatcher.Clone(),
 	}
 	res.Mock = mock
 	req.Mock = mock

--- a/mock_test.go
+++ b/mock_test.go
@@ -14,7 +14,7 @@ func TestNewMock(t *testing.T) {
 	res := NewResponse()
 	mock := NewMock(req, res)
 	st.Expect(t, mock.disabled, false)
-	st.Expect(t, mock.matcher, DefaultMatcher)
+	st.Expect(t, len(mock.matcher.Get()), len(DefaultMatcher.Get()))
 
 	st.Expect(t, mock.Request(), req)
 	st.Expect(t, mock.Request().Mock, mock)
@@ -71,7 +71,7 @@ func TestMockSetMatcher(t *testing.T) {
 	res := NewResponse()
 	mock := NewMock(req, res)
 
-	st.Expect(t, mock.matcher, DefaultMatcher)
+	st.Expect(t, len(mock.matcher.Get()), len(DefaultMatcher.Get()))
 	matcher := NewMatcher()
 	matcher.Flush()
 	matcher.Add(func(req *http.Request, ereq *Request) (bool, error) {
@@ -93,7 +93,7 @@ func TestMockAddMatcher(t *testing.T) {
 	res := NewResponse()
 	mock := NewMock(req, res)
 
-	st.Expect(t, mock.matcher, DefaultMatcher)
+	st.Expect(t, len(mock.matcher.Get()), len(DefaultMatcher.Get()))
 	matcher := NewMatcher()
 	matcher.Flush()
 	mock.SetMatcher(matcher)


### PR DESCRIPTION
Fixes #20 and #54.