### PR TITLE
Fix a couple of issue experienced around headers

### DIFF
--- a/_examples/match_headers/headers_test.go
+++ b/_examples/match_headers/headers_test.go
@@ -20,7 +20,7 @@ func TestMatchHeaders(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "http://foo.com", nil)
 	req.Header.Set("Authorization", "foo bar")
-	req.Header.Set("API", "1.0")
+	req.Header["API"]=[]string{ "1.0"}
 	req.Header.Set("Accept", "text/plain")
 
 	res, err := (&http.Client{}).Do(req)

--- a/_examples/match_headers/headers_test.go
+++ b/_examples/match_headers/headers_test.go
@@ -20,7 +20,7 @@ func TestMatchHeaders(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "http://foo.com", nil)
 	req.Header.Set("Authorization", "foo bar")
-	req.Header["API"]=[]string{ "1.0"}
+	req.Header["API"] = []string{"1.0"}
 	req.Header.Set("Accept", "text/plain")
 
 	res, err := (&http.Client{}).Do(req)

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,6 @@ module gopkg.in/h2non/gock.v1
 require (
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542
 	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32
+	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
+	gopkg.in/h2non/gentleman.v1 v1.0.4
 )

--- a/matchers.go
+++ b/matchers.go
@@ -77,18 +77,23 @@ func MatchHeaders(req *http.Request, ereq *Request) (bool, error) {
 	for key, value := range ereq.Header {
 		var err error
 		var match bool
+		var matchEscaped bool
 
 		for _, field := range req.Header[key] {
 			match, err = regexp.MatchString(value[0], field)
+			//Some values may contain reserved regex params e.g. "()", try matching with these escaped
+			matchEscaped, err = regexp.MatchString(regexp.QuoteMeta(value[0]), field)
+
 			if err != nil {
 				return false, err
 			}
-			if match {
+			if match || matchEscaped {
 				break
 			}
+
 		}
 
-		if !match {
+		if !match && !matchEscaped {
 			return false, nil
 		}
 	}

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -129,6 +129,7 @@ func TestMatchHeaders(t *testing.T) {
 		{http.Header{"foo": []string{"^bar$"}}, http.Header{"foo": []string{"barbar"}}, false},
 		{http.Header{"UPPERCASE": []string{"bar"}}, http.Header{"UPPERCASE": []string{"bar"}}, true},
 		{http.Header{"Mixed-CASE": []string{"bar"}}, http.Header{"Mixed-CASE": []string{"bar"}}, true},
+		{http.Header{"User-Agent": []string{"Agent (version1.0)"}}, http.Header{"User-Agent": []string{"Agent (version1.0)"}}, true},
 	}
 
 	for _, test := range cases {

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -130,6 +130,8 @@ func TestMatchHeaders(t *testing.T) {
 		{http.Header{"UPPERCASE": []string{"bar"}}, http.Header{"UPPERCASE": []string{"bar"}}, true},
 		{http.Header{"Mixed-CASE": []string{"bar"}}, http.Header{"Mixed-CASE": []string{"bar"}}, true},
 		{http.Header{"User-Agent": []string{"Agent (version1.0)"}}, http.Header{"User-Agent": []string{"Agent (version1.0)"}}, true},
+		{http.Header{"Content-Type": []string{"(.*)/plain"}}, http.Header{"Content-Type": []string{"text/plain"}}, true},
+
 	}
 
 	for _, test := range cases {

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -127,6 +127,8 @@ func TestMatchHeaders(t *testing.T) {
 		{http.Header{"foo": []string{"b(.*)"}}, http.Header{"foo": []string{"barbar"}}, true},
 		{http.Header{"foo": []string{"^bar$"}}, http.Header{"foo": []string{"bar"}}, true},
 		{http.Header{"foo": []string{"^bar$"}}, http.Header{"foo": []string{"barbar"}}, false},
+		{http.Header{"UPPERCASE": []string{"bar"}}, http.Header{"UPPERCASE": []string{"bar"}}, true},
+		{http.Header{"Mixed-CASE": []string{"bar"}}, http.Header{"Mixed-CASE": []string{"bar"}}, true},
 	}
 
 	for _, test := range cases {

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -131,7 +131,6 @@ func TestMatchHeaders(t *testing.T) {
 		{http.Header{"Mixed-CASE": []string{"bar"}}, http.Header{"Mixed-CASE": []string{"bar"}}, true},
 		{http.Header{"User-Agent": []string{"Agent (version1.0)"}}, http.Header{"User-Agent": []string{"Agent (version1.0)"}}, true},
 		{http.Header{"Content-Type": []string{"(.*)/plain"}}, http.Header{"Content-Type": []string{"text/plain"}}, true},
-
 	}
 
 	for _, test := range cases {

--- a/request.go
+++ b/request.go
@@ -207,7 +207,7 @@ func (r *Request) HeaderPresent(key string) *Request {
 // MatchHeaders defines a map of key-value headers to match.
 func (r *Request) MatchHeaders(headers map[string]string) *Request {
 	for key, value := range headers {
-		r.Header[key] =  []string{value}
+		r.Header[key] = []string{value}
 	}
 	return r
 }

--- a/request.go
+++ b/request.go
@@ -194,20 +194,20 @@ func (r *Request) BasicAuth(username, password string) *Request {
 
 // MatchHeader defines a new key and value header to match.
 func (r *Request) MatchHeader(key, value string) *Request {
-	r.Header.Set(key, value)
+	r.Header[key] = []string{value}
 	return r
 }
 
 // HeaderPresent defines that a header field must be present in the request.
 func (r *Request) HeaderPresent(key string) *Request {
-	r.Header.Set(key, ".*")
+	r.Header[key] = []string{".*"}
 	return r
 }
 
 // MatchHeaders defines a map of key-value headers to match.
 func (r *Request) MatchHeaders(headers map[string]string) *Request {
 	for key, value := range headers {
-		r.Header.Set(key, value)
+		r.Header[key] =  []string{value}
 	}
 	return r
 }

--- a/request_test.go
+++ b/request_test.go
@@ -15,7 +15,7 @@ func TestNewRequest(t *testing.T) {
 	st.Expect(t, req.URLStruct.Host, "foo.com")
 	st.Expect(t, req.URLStruct.Scheme, "http")
 	req.MatchHeader("foo", "bar")
-	st.Expect(t, req.Header.Get("foo"), "bar")
+	st.Expect(t, req.Header["foo"][0], "bar")
 }
 
 func TestRequestSetURL(t *testing.T) {
@@ -94,16 +94,25 @@ func TestRequestMatchHeader(t *testing.T) {
 	req := NewRequest()
 	req.MatchHeader("foo", "bar")
 	req.MatchHeader("bar", "baz")
-	st.Expect(t, req.Header.Get("foo"), "bar")
-	st.Expect(t, req.Header.Get("bar"), "baz")
+	req.MatchHeader("UPPERCASE","bat")
+	req.MatchHeader("Mixed-CASE","foo")
+
+	st.Expect(t, req.Header["foo"][0],"bar")
+	st.Expect(t, req.Header["bar"][0],"baz")
+	st.Expect(t, req.Header["UPPERCASE"][0],"bat")
+	st.Expect(t, req.Header["Mixed-CASE"][0],"foo")
 }
 
 func TestRequestHeaderPresent(t *testing.T) {
 	req := NewRequest()
 	req.HeaderPresent("foo")
 	req.HeaderPresent("bar")
-	st.Expect(t, req.Header.Get("foo"), ".*")
-	st.Expect(t, req.Header.Get("bar"), ".*")
+	req.HeaderPresent("UPPERCASE")
+	req.HeaderPresent("Mixed-CASE")
+	st.Expect(t, req.Header["foo"][0],".*")
+	st.Expect(t, req.Header["bar"][0],".*")
+	st.Expect(t, req.Header["UPPERCASE"][0],".*")
+	st.Expect(t, req.Header["Mixed-CASE"][0],".*")
 }
 
 func TestRequestMatchParam(t *testing.T) {

--- a/request_test.go
+++ b/request_test.go
@@ -94,13 +94,13 @@ func TestRequestMatchHeader(t *testing.T) {
 	req := NewRequest()
 	req.MatchHeader("foo", "bar")
 	req.MatchHeader("bar", "baz")
-	req.MatchHeader("UPPERCASE","bat")
-	req.MatchHeader("Mixed-CASE","foo")
+	req.MatchHeader("UPPERCASE", "bat")
+	req.MatchHeader("Mixed-CASE", "foo")
 
-	st.Expect(t, req.Header["foo"][0],"bar")
-	st.Expect(t, req.Header["bar"][0],"baz")
-	st.Expect(t, req.Header["UPPERCASE"][0],"bat")
-	st.Expect(t, req.Header["Mixed-CASE"][0],"foo")
+	st.Expect(t, req.Header["foo"][0], "bar")
+	st.Expect(t, req.Header["bar"][0], "baz")
+	st.Expect(t, req.Header["UPPERCASE"][0], "bat")
+	st.Expect(t, req.Header["Mixed-CASE"][0], "foo")
 }
 
 func TestRequestHeaderPresent(t *testing.T) {
@@ -109,10 +109,10 @@ func TestRequestHeaderPresent(t *testing.T) {
 	req.HeaderPresent("bar")
 	req.HeaderPresent("UPPERCASE")
 	req.HeaderPresent("Mixed-CASE")
-	st.Expect(t, req.Header["foo"][0],".*")
-	st.Expect(t, req.Header["bar"][0],".*")
-	st.Expect(t, req.Header["UPPERCASE"][0],".*")
-	st.Expect(t, req.Header["Mixed-CASE"][0],".*")
+	st.Expect(t, req.Header["foo"][0], ".*")
+	st.Expect(t, req.Header["bar"][0], ".*")
+	st.Expect(t, req.Header["UPPERCASE"][0], ".*")
+	st.Expect(t, req.Header["Mixed-CASE"][0], ".*")
 }
 
 func TestRequestMatchParam(t *testing.T) {


### PR DESCRIPTION
While mocking a third party API, I came across issues where Headers would not match because the headers required were in Upper case. 
This can be addressed in the http.Request by setting the map entries directly rather than having them sanitised when adding with http.RequestHeader.Add or http.Request.Header.Set.

The underlying code for the match already pulls the values from the map directly, but when the match is added, it uses Header.Set, meaning if I'm expecting a header like: "JANKY-UPPERCASE-HEADER" it will never match, because the matcher changes it to "Janky-Uppercase-Header".

This change allows this to be mocked as well. By setting the values to be matched explicitly to the Map when the Header Match is created.

This change also fixes issue #58 