### PR TITLE
Fix data races in New()

### DIFF
--- a/gock.go
+++ b/gock.go
@@ -61,7 +61,9 @@ func Intercepting() bool {
 // If you are using a custom HTTP transport, you have to use `gock.Transport()`
 func Intercept() {
 	if !Intercepting() {
+		mutex.Lock()
 		http.DefaultTransport = DefaultTransport
+		mutex.Unlock()
 	}
 }
 

--- a/gock_test.go
+++ b/gock_test.go
@@ -430,6 +430,7 @@ func TestObserve(t *testing.T) {
 }
 
 func TestTryCreatingRacesInNew(t *testing.T) {
+	defer after()
 	for i := 0; i < 10; i++ {
 		go func() {
 			New("http://example.com")

--- a/gock_test.go
+++ b/gock_test.go
@@ -430,7 +430,7 @@ func TestObserve(t *testing.T) {
 }
 
 func TestTryCreatingRacesInNew(t *testing.T) {
-	for i := 0; i < 100; {
+	for i := 0; i < 10; {
 		go func() {
 			New("http://example.com")
 		}()

--- a/gock_test.go
+++ b/gock_test.go
@@ -429,6 +429,14 @@ func TestObserve(t *testing.T) {
 	st.Expect(t, observedMock.Request().URLStruct.Host, "observe-foo.com")
 }
 
+func TestTryCreatingRacesInNew(t *testing.T) {
+	for i := 0; i < 100; {
+		go func() {
+			New("http://example.com")
+		}()
+	}
+}
+
 func after() {
 	Flush()
 	Disable()

--- a/gock_test.go
+++ b/gock_test.go
@@ -430,7 +430,7 @@ func TestObserve(t *testing.T) {
 }
 
 func TestTryCreatingRacesInNew(t *testing.T) {
-	for i := 0; i < 10; {
+	for i := 0; i < 10; i++ {
 		go func() {
 			New("http://example.com")
 		}()

--- a/matcher.go
+++ b/matcher.go
@@ -77,6 +77,8 @@ func NewEmptyMatcher() *MockMatcher {
 
 // Get returns a slice of registered function matchers.
 func (m *MockMatcher) Get() []MatchFunc {
+	mutex.Lock()
+	defer mutex.Unlock()
 	return m.Matchers
 }
 

--- a/store.go
+++ b/store.go
@@ -17,8 +17,8 @@ func Register(mock Mock) {
 	}
 
 	// Make ops thread safe
-	mutex.Lock()
-	defer mutex.Unlock()
+	storeMutex.Lock()
+	defer storeMutex.Unlock()
 
 	// Expose mock in request/response for delegation
 	mock.Request().Mock = mock


### PR DESCRIPTION
There are a lot of gock.New calls in my use case and race detector points at data races in New().
This PR is an attempt to fix these data races.