### PR TITLE
fix: Rename example function

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ import (
   "testing"
 )
 
-func TestMatchHeaders(t *testing.T) {
+func TestMatchParams(t *testing.T) {
   defer gock.Off()
 
   gock.New("http://foo.com").


### PR DESCRIPTION
Fix function name in the README example to a more appropriate one