### PR TITLE
fix: Broken example

### DIFF
--- a/_examples/match_headers/headers_test.go
+++ b/_examples/match_headers/headers_test.go
@@ -1,11 +1,12 @@
 package test
 
 import (
-	"github.com/nbio/st"
-	"gopkg.in/h2non/gock.v1"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/nbio/st"
+	"gopkg.in/h2non/gock.v1"
 )
 
 func TestMatchHeaders(t *testing.T) {
@@ -20,7 +21,7 @@ func TestMatchHeaders(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "http://foo.com", nil)
 	req.Header.Set("Authorization", "foo bar")
-	req.Header["API"] = []string{"1.0"}
+	req.Header.Set("API", "1.0")
 	req.Header.Set("Accept", "text/plain")
 
 	res, err := (&http.Client{}).Do(req)


### PR DESCRIPTION
Resolves this https://github.com/h2non/gock/pull/78#issuecomment-763704077

Sorry for not catching this the first time round. FYI [this](https://github.com/h2non/gock/blob/master/_examples/reply_error/reply_error_test.go#L12) test is failing for me locally. I'm not sure why, but it passed on the CI link you sent, so I've left it alone.
```go
$ go test -race ./_examples/*/
--- FAIL: TestReplyError (0.00s)
    st.go:41: 
        reply_error_test.go:20: should be == 
                have: (string) Get "http://foo.com/bar": Error dude!
                want: (string) Get http://foo.com/bar: Error dude!
```