### PR TITLE
Add failing test for Persist()

### DIFF
--- a/_examples/persistent/persistent_test.go
+++ b/_examples/persistent/persistent_test.go
@@ -23,4 +23,7 @@ func TestPersistent(t *testing.T) {
 		body, _ := ioutil.ReadAll(res.Body)
 		st.Expect(t, string(body)[:13], `{"foo":"bar"}`)
 	}
+
+	// Verify that we don't have pending mocks
+	st.Expect(t, gock.IsDone(), true)
 }


### PR DESCRIPTION
nock seem to consider a mock marked with `Persist()` as used when called at least once. But in gock `IsDone()` always returns `false` whether the mock has been called or not…