### PR TITLE
Add context expiration cancellation support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module gopkg.in/h2non/gock.v1
 
+go 1.13
+
 require (
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542
 	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32
-	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
-	gopkg.in/h2non/gentleman.v1 v1.0.4
 )

--- a/responder_test.go
+++ b/responder_test.go
@@ -1,10 +1,12 @@
 package gock
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/nbio/st"
 )
@@ -61,5 +63,58 @@ func TestResponderError(t *testing.T) {
 
 	res, err := Responder(req, mres, nil)
 	st.Expect(t, err.Error(), "error")
+	st.Expect(t, res == nil, true)
+}
+
+func TestResponderCancelledContext(t *testing.T) {
+	defer after()
+	mres := New("http://foo.com").Get("").Reply(200).Delay(20*time.Millisecond).BodyString("foo")
+
+	// create a context and schedule a call to cancel in 10ms
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10*time.Millisecond)
+		cancel()
+	}()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://foo.com", nil)
+
+	res, err := Responder(req, mres, nil)
+
+	// verify that we got a context cancellation error and nil response
+	st.Expect(t, err, context.Canceled)
+	st.Expect(t, res == nil, true)
+}
+
+func TestResponderExpiredContext(t *testing.T) {
+	defer after()
+	mres := New("http://foo.com").Get("").Reply(200).Delay(20*time.Millisecond).BodyString("foo")
+
+	// create a context that is set to expire in 10ms
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://foo.com", nil)
+
+	res, err := Responder(req, mres, nil)
+
+	// verify that we got a context cancellation error and nil response
+	st.Expect(t, err, context.DeadlineExceeded)
+	st.Expect(t, res == nil, true)
+}
+
+func TestResponderPreExpiredContext(t *testing.T) {
+	defer after()
+	mres := New("http://foo.com").Get("").Reply(200).BodyString("foo")
+
+	// create a context and wait to ensure it is expired
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Microsecond)
+	defer cancel()
+	time.Sleep(1*time.Millisecond)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://foo.com", nil)
+
+	res, err := Responder(req, mres, nil)
+
+	// verify that we got a context cancellation error and nil response
+	st.Expect(t, err, context.DeadlineExceeded)
 	st.Expect(t, res == nil, true)
 }

--- a/responder_test.go
+++ b/responder_test.go
@@ -68,12 +68,12 @@ func TestResponderError(t *testing.T) {
 
 func TestResponderCancelledContext(t *testing.T) {
 	defer after()
-	mres := New("http://foo.com").Get("").Reply(200).Delay(20*time.Millisecond).BodyString("foo")
+	mres := New("http://foo.com").Get("").Reply(200).Delay(20 * time.Millisecond).BodyString("foo")
 
 	// create a context and schedule a call to cancel in 10ms
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		time.Sleep(10*time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 		cancel()
 	}()
 
@@ -88,7 +88,7 @@ func TestResponderCancelledContext(t *testing.T) {
 
 func TestResponderExpiredContext(t *testing.T) {
 	defer after()
-	mres := New("http://foo.com").Get("").Reply(200).Delay(20*time.Millisecond).BodyString("foo")
+	mres := New("http://foo.com").Get("").Reply(200).Delay(20 * time.Millisecond).BodyString("foo")
 
 	// create a context that is set to expire in 10ms
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -109,7 +109,7 @@ func TestResponderPreExpiredContext(t *testing.T) {
 	// create a context and wait to ensure it is expired
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Microsecond)
 	defer cancel()
-	time.Sleep(1*time.Millisecond)
+	time.Sleep(1 * time.Millisecond)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://foo.com", nil)
 
 	res, err := Responder(req, mres, nil)


### PR DESCRIPTION
Add support for expired and cancelled contexts, both with and without delay operations. This should make the behavior of gock mocks more similar to actual HTTP upstreams using the standard HTTP client.

Note that this change fundamentally requires go version 1.13 or greater. As such, `go.mod` was updated accordingly.

Resolves #84