### PR TITLE
feat(matchers): Add custom body type matcher

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -148,7 +148,7 @@ func MatchBody(req *http.Request, ereq *Request) (bool, error) {
 	}
 
 	// Only can match certain MIME body types
-	if !supportedType(req) {
+	if !supportedType(req, ereq) {
 		return false, nil
 	}
 
@@ -214,10 +214,15 @@ func MatchBody(req *http.Request, ereq *Request) (bool, error) {
 	return false, nil
 }
 
-func supportedType(req *http.Request) bool {
+func supportedType(req *http.Request, ereq *Request) bool {
 	mime := req.Header.Get("Content-Type")
 	if mime == "" {
 		return true
+	}
+
+	mimeToMatch := ereq.Header.Get("Content-Type")
+	if mimeToMatch != "" {
+		return mime == mimeToMatch
 	}
 
 	for _, kind := range BodyTypes {

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -222,3 +222,30 @@ func TestMatchBody(t *testing.T) {
 		st.Expect(t, matches, test.matches)
 	}
 }
+
+func TestMatchBody_MatchType(t *testing.T) {
+	body := `{"foo":"bar"}`
+	cases := []struct {
+		body               string
+		requestContentType string
+		customBodyType     string
+		matches            bool
+	}{
+		{body, "application/vnd.apiname.v1+json", "foobar", false},
+		{body, "application/vnd.apiname.v1+json", "application/vnd.apiname.v1+json", true},
+		{body, "application/json", "foobar", false},
+		{body, "application/json", "", true},
+		{"", "", "", true},
+	}
+
+	for _, test := range cases {
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{test.requestContentType}},
+			Body:   createReadCloser([]byte(test.body)),
+		}
+		ereq := NewRequest().BodyString(test.body).MatchType(test.customBodyType)
+		matches, err := MatchBody(req, ereq)
+		st.Expect(t, err, nil)
+		st.Expect(t, matches, test.matches)
+	}
+}

--- a/request.go
+++ b/request.go
@@ -176,7 +176,7 @@ func (r *Request) XML(data interface{}) *Request {
 }
 
 // MatchType defines the request Content-Type MIME header field.
-// Supports type alias. E.g: json, xml, form, text...
+// Supports custom MIME types and type aliases. E.g: json, xml, form, text...
 func (r *Request) MatchType(kind string) *Request {
 	mime := BodyTypeAliases[kind]
 	if mime != "" {


### PR DESCRIPTION
PR to add the custom body type matcher that was proposed in https://github.com/h2non/gock/issues/87

The logic is pretty simple - If a user passes a non-empty mime type to the BodyType function, then the `Content-Type` header on the http request must be the same for there to be a match. If there's no mime type passed then it falls back to the the existing logic of checking against the hardcoded list of supported mime types.

One thing I'm a bit unsure of - I discovered [`MatchType`](https://github.com/h2non/gock/blob/master/request.go#L180-L187) and now I feel like adding this additional method will be confusing to people, since there will be two separate methods for matching based on the `Content-Type` header but the behaviour is different.

@h2non Any thoughts on this?