### PR TITLE
Response BodyGenerator()

### DIFF
--- a/responder.go
+++ b/responder.go
@@ -43,6 +43,12 @@ func Responder(req *http.Request, mock *Response, res *http.Response) (*http.Res
 		res.Body = createReadCloser(mock.BodyBuffer)
 	}
 
+	// Set raw mock body, if exist
+	if mock.BodyGen != nil {
+		res.ContentLength = -1
+		res.Body = mock.BodyGen()
+	}
+
 	// Apply response mappers
 	for _, mapper := range mock.Mappers {
 		if tres := mapper(res); tres != nil {

--- a/response.go
+++ b/response.go
@@ -37,6 +37,9 @@ type Response struct {
 	// Cookies stores the response cookie fields.
 	Cookies []*http.Cookie
 
+	// BodyGen stores a io.ReadCloser generator to be returned.
+	BodyGen func() io.ReadCloser
+
 	// BodyBuffer stores the array of bytes to use as body.
 	BodyBuffer []byte
 
@@ -96,6 +99,13 @@ func (r *Response) SetHeaders(headers map[string]string) *Response {
 // Body sets the HTTP response body to be used.
 func (r *Response) Body(body io.Reader) *Response {
 	r.BodyBuffer, r.Error = ioutil.ReadAll(body)
+	return r
+}
+
+// BodyGenerator accepts a io.ReadCloser generator, returning custom io.ReadCloser
+// for every response. This will take priority than other Body methods used.
+func (r *Response) BodyGenerator(generator func() io.ReadCloser) *Response {
+	r.BodyGen = generator
 	return r
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -3,6 +3,7 @@ package gock
 import (
 	"bytes"
 	"errors"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -74,6 +75,17 @@ func TestResponseBody(t *testing.T) {
 	res := NewResponse()
 	res.Body(bytes.NewBuffer([]byte("foo bar")))
 	st.Expect(t, string(res.BodyBuffer), "foo bar")
+}
+
+func TestResponseBodyGenerator(t *testing.T) {
+	res := NewResponse()
+	generator := func() io.ReadCloser {
+		return io.NopCloser(bytes.NewBuffer([]byte("foo bar")))
+	}
+	res.BodyGenerator(generator)
+	bytes, err := io.ReadAll(res.BodyGen())
+	st.Expect(t, err, nil)
+	st.Expect(t, string(bytes), "foo bar")
 }
 
 func TestResponseBodyString(t *testing.T) {


### PR DESCRIPTION
Adding ability to add `BodyGenerator()` for more customization in defining response body. I use this library a lot for unit testing, and one of the unit test I haven't been able to cover is in cases where we fail to call `Read()` from response body. We cannot add a simple mock `io.ReadCloser` interface that return an error when `Read()` is being called because `Body` are stored as a bytes buffer, and error are handled when creating new response body, so application level code will never encounter a faulty body.

This PR added a new Body type for Response, which is the `BodyGenerator` function, that takes in a function which returns an `io.ReadCloser`, which will be thing that will be returned as a response.

p.s. I wanted to have it cleaner by having a `BodyRaw(io.ReadCloser)` function, but cannot get it to work with multiple response, as it will return the same pointer to the underlying implementation of `io.ReadCloser`, which means after the first `Read()` to the response body, the second response body `Read()` function will be different, making the behaviour unexpected. If you guys know how to only accept `io.ReadCloser` interface and not a function to generate one (maybe using reflection), please let me know and I'll try to implement it here