### PR TITLE
Fix race condition in Remove()

### DIFF
--- a/store.go
+++ b/store.go
@@ -49,11 +49,11 @@ func Exists(m Mock) bool {
 
 // Remove removes a registered mock by reference.
 func Remove(m Mock) {
+	storeMutex.Lock()
+	defer storeMutex.Unlock()
 	for i, mock := range mocks {
 		if mock == m {
-			storeMutex.Lock()
 			mocks = append(mocks[:i], mocks[i+1:]...)
-			storeMutex.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
There's a race condition in `store.go`'s remove, where `mocks` can change between finding `m` and acquiring the lock.

The fix is rather simple, simply acquire write lock before searching and modifying `mocks`.